### PR TITLE
Add Mise Config File

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,6 @@
+[tools]
+
+erlang = '26.2'
+elixir = '1.17.2-otp-26'
+postgres = '15.6'
+node = '22.5.1'


### PR DESCRIPTION
We are using [Mise](https://mise.jdx.dev) for this project to ensure that versions for the tools used are consistent.